### PR TITLE
Optionally allow underscore

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -1,3 +1,4 @@
 dnspython
 mypy
 Pydantic
+hname

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -1,2 +1,3 @@
 dnspython
 mypy
+Pydantic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Much to my surprise, or perhaps simply failure to search properly,
 there is no RFC compliant python tool for that syntactically validates hostnames.
 Note that not all valid domain names are valid hostnames.
 
-To validated domain names, I recommend [dnspython](https://www.dnspython.org), and to validate Urls
+To validated domain names, I recommend [dnspython],
+and to validate Urls
 I recommend [Pydantic](https://docs.pydantic.dev/latest/).
 But neither offers direct validation of hostnames.
 
@@ -13,5 +14,56 @@ But neither offers direct validation of hostnames.
 A host for many internet protocols can be given in the form of a domain name, an IPv4 address, or an IPv6 address. I will use the term "hostname" to require to the domain name form.
 A hostname must be a valid domain name, but not all valid domain names are hostnames.
 
+## Standard interpretation
+
+The primary basis for what is and is not a valid hostname comes from [RFC952] (with updates from [RFC1123] and [RFC5890]).
+
+### Labelling labels
+
+In the discussion here, I will use the term “label” to refer to a part of a hostname that appears between the dots.
+For example the hostname "`bar.foo.example`" has three labels.[^4]:
+"`bar`", "`foo`", and "`exmaple`".
+There are requirements that are specific to the last (rightmost) label,
+and there may be things that are allowed only in the first (leftmost) label.
+In the example, "`bar`" is the first (leftmost) label, and "`example`" is the last (rightmost) label.
+
+[^4]: I am not counting the invisible root label, "", in this discussion.
+
+### RFC952: Hosts, etc
+
+[RFC952] codifies hostname conventions which emerged prior to the Domain Name System.
+It tells us that a valid hostname ("hname" in the grammar given) conforms to
+
+```txt
+<hname> ::= <name>*["."<name>]
+<name>  ::= <let>[*[<let-or-digit-or-hyphen>]<let-or-digit>]
+```
+
+Roughly that is a string of labels dot separated labels ("name" in that grammar.
+The first character of a label
+(and there must be a first character)
+must be a letter[^3].
+The last character of a label must be a letter or a digit.
+Internal characters must be a letter, or a digit, or a hyphen.
+
+### [RFC1123] Domain name requirements
+
+[RFC1123] says that a valid hostname must also be a valid domain name.
+But it is also clear that not every valid domain name is a valid hostname.
+Hostnames must meet both the requirements of [RFC952] and of valid hostnames.
+It does, however, amend [RFC952] to allow the first character of a label to be a digit.
+If I recall correctly, this was informally called "the 3Com amendment" at the time.
+
+The additional requirements on hostnames that come from [RFC1123] impose length restrictions on labels (63 bytes) and on the entire name (254 bytes).
+
+The Hostname package uses the excellent [dnspython] to validate that its input is a valid domain name.
+
+[^3]: [RFC1123] amends the restriction on the first character, allowing it to be a digit as well as a letter. [RFC5890] and friends radically change what counts as an allowable letter.
+
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
+[RFC952]: https://datatracker.ietf.org/doc/html/rfc952 "Host Table Specification"
+[RFC1123]:  https://datatracker.ietf.org/doc/html/rfc1123 "Requirements for Internet Hosts"
+[RFC5890]: https://datatracker.ietf.org/doc/html/rfc5890 "IDNA Definitions"
+[dnspython]: https://www.dnspython.org "DNS toolkit for Python"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A hostname must be a valid domain name, but not all valid domain names are hostn
 
 ## Standard interpretation
 
-The primary basis for what is and is not a valid hostname comes from [RFC952] (with updates from [RFC1123] and [RFC5890]).
+The primary basis for what is and is not a valid hostname comes from [RFC-952] (with updates from [RFC-1123] and [RFC-5890]).
 
 ### Labelling labels
 
@@ -33,7 +33,7 @@ In the example, "`bar`" is the first (leftmost) label, and "`example`" is the la
 
 ### RFC952: Hosts, etc
 
-[RFC952] codifies hostname conventions which emerged prior to the Domain Name System.
+[RFC-952] codifies hostname conventions which emerged prior to the Domain Name System.
 It tells us that a valid hostname ("hname" in the grammar given) conforms to
 
 ```txt
@@ -44,28 +44,57 @@ It tells us that a valid hostname ("hname" in the grammar given) conforms to
 Roughly that is a string of labels dot separated labels ("name" in that grammar.
 The first character of a label
 (and there must be a first character)
-must be a letter[^3].
+must be a letter.
+The requirement that it be a letter was later dropped.
 The last character of a label must be a letter or a digit.
 Internal characters must be a letter, or a digit, or a hyphen.
 
-### [RFC1123] Domain name requirements
+### Length restrictions
 
-[RFC1123] says that a valid hostname must also be a valid domain name.
-But it is also clear that not every valid domain name is a valid hostname.
-Hostnames must meet both the requirements of [RFC952] and of valid hostnames.
-It does, however, amend [RFC952] to allow the first character of a label to be a digit.
-If I recall correctly, this was informally called "the 3Com amendment" at the time.
+RFCs [1034][RFC-1034] and [1123][RFC-1123] introduce additional requirements on hostnames.
 
-The additional requirements on hostnames that come from [RFC1123] impose length restrictions on labels (63 bytes) and on the entire name (254 bytes).
+[RFC-1123] makes it clear that a hostname must also be a valid domain name.
+So all requirements on domain names must apply to hostnames.
+Of course not all valid domain names are valid hostnames.
+After all, `*&.!!+1.()` is a valid domain name, but is certainly not a valid hostname.
+
+Section 3.1 of [RFC-1034] specifies a length limits of 63 bytes on labels,
+and 255 bytes for the entire domain name. That 255 includes a root "." and root domain.
+And so domain names without the trailing dot can have a maximum length of 253 bytes.
 
 The Hostname package uses the excellent [dnspython] to validate that its input is a valid domain name.
 
-[^3]: [RFC1123] amends the restriction on the first character, allowing it to be a digit as well as a letter. [RFC5890] and friends radically change what counts as an allowable letter.
+### Digits first
+
+Section 2.1 of [RFC-1123] amends the restriction on the first character, allowing it to be a digit as well as a letter.
+
+> The syntax of a legal Internet host name was specified in [RFC-952].
+> One aspect of host name syntax is hereby changed: the
+> restriction on the first character is relaxed to allow either a
+> letter or a digit.  Host software MUST support this more liberal syntax.
+
+This allowed hostnames such as `3Com.net`.[^3]
+
+[^3]: 3Com was a a leading network technology company at the time that these standards were developed.
+
+### IDNA
+
+To do
+
+[RFC-5890] and friends radically change what counts as an allowable letter.
+
+### Underscore
+
+To Do
+
+
+----
 
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-[RFC952]: https://datatracker.ietf.org/doc/html/rfc952 "Host Table Specification"
-[RFC1123]:  https://datatracker.ietf.org/doc/html/rfc1123 "Requirements for Internet Hosts"
-[RFC5890]: https://datatracker.ietf.org/doc/html/rfc5890 "IDNA Definitions"
+[RFC-952]: https://datatracker.ietf.org/doc/html/rfc952 "Host Table Specification"
+[RFC-1123]:  https://datatracker.ietf.org/doc/html/rfc1123 "Requirements for Internet Hosts"
+[RFC-5890]: https://datatracker.ietf.org/doc/html/rfc5890 "IDNA Definitions"
 [dnspython]: https://www.dnspython.org "DNS toolkit for Python"
+[RFC-1034]: https://datatracker.ietf.org/doc/html/rfc1034 "Domain Name Concepts"

--- a/README.md
+++ b/README.md
@@ -77,16 +77,39 @@ This allowed hostnames such as `3Com.net`.[^3]
 
 [^3]: 3Com was a a leading network technology company at the time that these standards were developed.
 
-### IDNA
-
-To do
-
-[RFC-5890] and friends radically change what counts as an allowable letter.
-
 ### Underscore
+
+The standards do not allow the underscore character, "`_`", to appear in a hostname.
+However some Internet software doesn't enforce that, and there was a time when some systems created such names in the most local (leftmost) part of a hostname.
+
+As I recall, Microsoft's Windows 95 operating system produced hostnames with underscores.
+Locally machines names could have names like "`Alices Computer`".
+When Windows 95 needed to present that to the Internet as a hostname label,
+it would convert it to "`alices_computer`".
+This was certainly the case when constructed the SMTP `HELO` message,
+which required the client's hostname.
+
+Sendmail, the overwhelmingly dominant mail transport agent at the time,
+allowed hostnames with underscores.
+Sendmail's acceptance of invalid hostnames  had probably been programming oversight at the time instead of a deliberate decision.
+The combination of
+a large number hosts sending invalid hostnames to major parts of Internet infrastructure
+which in turn accepted those invalid hostname
+led to such malformed hostnames being widely accepted.
+There almost certainly is more to the story than I was aware of or recall,
+but hostnames with underscores became widely accepted.
+
+By default `is_hostname()` rejects candidate hostnames with underscores.
+There is a flag, `HostnameFlags.ALLOW_UNDERSCORE` that enables underscores in
+the leftmost label only.
+My recommendation is to only set the flag if you have a compelling reason to.
+Syntactically invalid hostnames should be discouraged.
+
+### IDNA
 
 To Do
 
+[RFC-5890] and friends radically change what counts as an allowable letter.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# `is_hostname()` for python
+# Validating hostnames
+
+The Hostname package provides an `is_hostnbame(str: candidate)` function, which performs syntactic validation of candidate hostname
 
 Much to my surprise, or perhaps simply failure to search properly,
-there is no RFC compliant python tool for that syntactically validates hostnames.
+there is no RFC compliant python tool that syntactically validates hostnames.
 Note that not all valid domain names are valid hostnames.
 
 To validated domain names, I recommend [dnspython],

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import ClassVar, TypeAlias
 
-from hostname import hostname
+import hostname.hostname as hn
 
 
 class TestHostname(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestHostname(unittest.TestCase):
     def test_is_hostname(self) -> None:
         for data, expected, desc in self.test_strings:
             with self.subTest(msg=desc):
-                result = hostname.Hostname.is_hostname(data)
+                result = hn.Hostname.is_hostname(data)
                 self.assertEqual(result, expected)
 
 
@@ -44,7 +44,7 @@ class TestHostnameUnderscore(unittest.TestCase):
     def test_is_hostname(self) -> None:
         for data, expected, desc in self.test_strings:
             with self.subTest(msg=desc):
-                result = hostname.Hostname.is_hostname(data, allow_underscore=True)
+                result = hn.Hostname.is_hostname(data, hn.HostnameFlag.ALLOW_UNDERSCORE)
                 self.assertEqual(result, expected)
 
 

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -26,5 +26,27 @@ class TestHostname(unittest.TestCase):
                 self.assertEqual(result, expected)
 
 
+class TestHostnameUnderscore(unittest.TestCase):
+    TestString: TypeAlias = tuple[str, bool, str]
+
+    test_strings: ClassVar[list[TestString]] = [
+        ("a.good.example", True, "simple"),
+        ("-initial.hyphen.example", False, "leading hyphen"),
+        ("szárba.szökik.hu", True, "idna"),
+        ("no..empty.labels", False, "empty label"),
+        ("123.456.78a", True, "digit labels ok"),
+        ("last.digits.123", False, "last label digits"),
+        ("3com.net", True, "Initial digit"),
+        ("under_score.in.host", True, "allowed with option"),
+        ("underscore.in.net_work", False, "not allowed in network names"),
+    ]
+
+    def test_is_hostname(self) -> None:
+        for data, expected, desc in self.test_strings:
+            with self.subTest(msg=desc):
+                result = hostname.Hostname.is_hostname(data, allow_underscore=True)
+                self.assertEqual(result, expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1 

There are several ugly hacks for this. The ugliest is the trick used to avoid having a conditional check for the flag within the loop. I am not happy with my solution. See the variable `underHack` if you wish to see it.

The second ugly hack is the mechanism to allow the underscore for the first label only.

This also adds HostnameFlag. The flag to allow underscores in the first label is `HostnameFlag.ALLOW_UNDERSCORE`. Creating a system with flags allows for more flags to be added later. It also gave me the opportunity to learn about enums in Python.