### PR TITLE
provide `validate` class method which raises useful exceptions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+
+
+
+        {
+            "name": "Debug",
+            "type": "python",
+            "request": "launch",
+            // "program": "${file}",
+            "program": "${relativeFileDirname}/${fileBasename}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "env": { "PYTHONPATH": "${workspaceRoot}"},
+            "cwd": "${workspaceFolder}",
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
         "markdown",
         "latex",
         "plaintext"
-    ]
+    ],
+    "cmake.configureOnOpen": true
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Validating hostnames
 
-The Hostname package provides an `is_hostnbame(str: candidate)` function, which performs syntactic validation of candidate hostname
+The Hostname package provides an `is_hostnbame(candidate: str)` boolean function, which performs syntactic validation of candidate hostname.
+Additionally, it provides as `validate(candidate: str)` function which raises informative exceptions if the candidate is not a valid hostname.
 
 Much to my surprise, or perhaps simply failure to search properly,
 there is no RFC compliant python tool that syntactically validates hostnames.

--- a/hostname/exception.py
+++ b/hostname/exception.py
@@ -7,8 +7,8 @@ import dns.name
 class HostnameException(dns.exception.DNSException):
     """A generic expection abstractions"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
 
 
 class UnderscoreError(HostnameException):
@@ -39,5 +39,5 @@ class DomainNameException(HostnameException):
     supp_kwargs = {"dns_exception"}
     fmt = "DNS syntax error: {dns_exception}"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)

--- a/hostname/exception.py
+++ b/hostname/exception.py
@@ -1,0 +1,35 @@
+# This is intended to wrap dns.exception
+
+import dns.exception
+import dns.name
+
+
+class HostnameException(dns.exception.DNSException):
+    """A generic expection abstractions"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class UnderscoreError(HostnameException):
+    """An underscore appeared in a label it shouldn't have."""
+
+
+class InvalidCharacter(HostnameException):
+    """A forbidden character was found in a lable"""
+
+
+class DigitOnlyError(HostnameException):
+    """The rightmost label is contains only digits"""
+
+
+# Looking at how dnspython handles INDA exceptions and doing
+# that here wrt to DNS errors
+class DomainNameException(HostnameException):
+    """DNS Parsing raised an exception"""
+
+    supp_kwargs = {"dns_exception"}
+    fmt = "DNS syntax error: {dns_exception}"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/hostname/exception.py
+++ b/hostname/exception.py
@@ -23,6 +23,14 @@ class DigitOnlyError(HostnameException):
     """The rightmost label is contains only digits"""
 
 
+class NoLabelError(HostnameException):
+    """Hostnames must have at least 1 label"""
+
+
+class BadHyphenError(HostnameException):
+    """A hyphen is used at the beginning or end of a label"""
+
+
 # Looking at how dnspython handles INDA exceptions and doing
 # that here wrt to DNS errors
 class DomainNameException(HostnameException):

--- a/hostname/exception.py
+++ b/hostname/exception.py
@@ -5,7 +5,7 @@ import dns.name
 
 
 class HostnameException(dns.exception.DNSException):
-    """A generic expection abstractions"""
+    """A generic exception abstraction"""
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
@@ -16,7 +16,7 @@ class UnderscoreError(HostnameException):
 
 
 class InvalidCharacter(HostnameException):
-    """A forbidden character was found in a lable"""
+    """A forbidden character was found in a label"""
 
 
 class DigitOnlyError(HostnameException):

--- a/hostname/hostname.py
+++ b/hostname/hostname.py
@@ -1,7 +1,7 @@
 from typing import Any, Self, TypeGuard
 from enum import Flag, auto
 
-import exception
+import hostname.exception as exc
 
 import dns.name
 import dns.exception
@@ -51,7 +51,7 @@ class Hostname:
         try:
             dname: dns.name.Name = dns.name.from_text(s).canonicalize()
         except Exception as e:
-            raise exception.DomainNameException(dns_exception=e) from e
+            raise exc.DomainNameException(dns_exception=e) from e
 
         labels: tuple[bytes, ...] = dname.labels
 
@@ -60,7 +60,7 @@ class Hostname:
 
         # Reject empty hostname
         if len(labels) == 0:
-            raise exception.NoLabelError
+            raise exc.NoLabelError
 
         for label in labels:
             cls._validate_label(label, flags)  # will raise exceptions on failure
@@ -70,7 +70,7 @@ class Hostname:
 
         # Last (most significant) label cannot be all digits
         if all(c >= cls._DIGIT_0 and c <= cls._DIGIT_9 for c in labels[-1]):
-            raise exception.DigitOnlyError
+            raise exc.DigitOnlyError
 
         return dname.to_text()
 
@@ -133,11 +133,11 @@ class Hostname:
                 or c == underHack
             ):
                 if c == cls._UNDERSCORE:
-                    raise exception.UnderscoreError
+                    raise exc.UnderscoreError
                 else:
-                    raise exception.InvalidCharacter
+                    raise exc.InvalidCharacter
             # Starting or ending with "-" is also forbidden.
 
         if cls._HYPHEN in (label[0], label[-1]):
-            raise exception.BadHyphenError
+            raise exc.BadHyphenError
         return True

--- a/hostname/hostname.py
+++ b/hostname/hostname.py
@@ -85,7 +85,7 @@ class Hostname:
         """
 
         try:
-            cls.validate(cls, s, flags)
+            cls.validate(s, flags)
         except Exception:
             return False
         return True

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -20,6 +20,8 @@ class TestHostname(unittest.TestCase):
         ("under_score.in.host", False, "Controversial: no underscore at all", exc.UnderscoreError),
         ("underscore.in.net_work", False, "not allowed in network names", exc.UnderscoreError),
         ("3com.net", True, "Initial digit", None),
+        ("", False, "empty", exc.NoLabelError),
+        ("a.b@d.example", False, "invalid character", exc.InvalidCharacter),
     ]
 
     def test_is_hostname(self) -> None:
@@ -42,6 +44,8 @@ class TestHostnameUnderscore(unittest.TestCase):
         ("3com.net", True, "Initial digit"),
         ("under_score.in.host", True, "allowed with option"),
         ("underscore.in.net_work", False, "not allowed in network names"),
+        ("", False, "empty"),
+        ("a.b@d.example", False, "invalid character"),
     ]
 
     def test_is_hostname(self) -> None:
@@ -64,6 +68,8 @@ class TestExceptions(unittest.TestCase):
         ("under_score.in.host", False, "Controversial: no underscore at all", exc.UnderscoreError),
         ("underscore.in.net_work", False, "not allowed in network names", exc.UnderscoreError),
         ("3com.net", True, "Initial digit", None),
+        ("", False, "empty", exc.NoLabelError),
+        ("a.b@d.example", False, "invalid character", exc.InvalidCharacter),
     ]
 
     def test_validate(self) -> None:

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -1,12 +1,14 @@
 import unittest
-from typing import ClassVar, TypeAlias, Optional
+from typing import ClassVar, TypeAlias, Union, Type, Tuple
 
 import hostname.hostname as hn
 import hostname.exception as exc
 
+ExcptionType = Union[None, Type[Exception], Tuple[Type[Exception], ...]]
+
 
 class TestHostname(unittest.TestCase):
-    TestString: TypeAlias = tuple[str, bool, str, Optional[exc.HostnameException]]
+    TestString: TypeAlias = tuple[str, bool, str, ExcptionType]
 
     test_strings: ClassVar[list[TestString]] = [
         ("a.good.example", True, "simple", None),
@@ -18,7 +20,7 @@ class TestHostname(unittest.TestCase):
         ("under_score.in.host", False, "Controversial: no underscore at all", exc.UnderscoreError),
         ("underscore.in.net_work", False, "not allowed in network names", exc.UnderscoreError),
         ("3com.net", True, "Initial digit", None),
-    ]  # type: ignore
+    ]
 
     def test_is_hostname(self) -> None:
         for data, expected, desc, _ in self.test_strings:
@@ -50,7 +52,7 @@ class TestHostnameUnderscore(unittest.TestCase):
 
 
 class TestExceptions(unittest.TestCase):
-    TestString: TypeAlias = tuple[str, bool, str, Optional[exc.HostnameException]]
+    TestString: TypeAlias = tuple[str, bool, str, ExcptionType]
 
     test_strings: ClassVar[list[TestString]] = [
         ("a.good.example", True, "simple", None),
@@ -62,7 +64,7 @@ class TestExceptions(unittest.TestCase):
         ("under_score.in.host", False, "Controversial: no underscore at all", exc.UnderscoreError),
         ("underscore.in.net_work", False, "not allowed in network names", exc.UnderscoreError),
         ("3com.net", True, "Initial digit", None),
-    ]  # type: ignore
+    ]
 
     def test_validate(self) -> None:
         for data, _, desc, exception in self.test_strings:


### PR DESCRIPTION
`is_hostname()` is a useful boolean function, but when it returns `False` it gives you no information about why it failed. `validate()` raises exceptions, which may be useful. Note that it chains exceptions from dnspython as well as adding hostname specific exceptions.